### PR TITLE
fix: textinput hides on keyboard open issue fixed

### DIFF
--- a/src/containers/chat/Chats.tsx
+++ b/src/containers/chat/Chats.tsx
@@ -55,10 +55,10 @@ const Chats = () => {
       page: currentPageRef.current,
     };
     let res: any = await dispatch(getUserChatsThunk(userChatParams));
+    setLoading(false);
     if (res.meta.requestStatus === 'fulfilled') {
       setChats(pre => pre.concat(res.payload.data));
       totalPagesRef.current = res.payload.pages;
-      setLoading(false);
     }
   }, [dispatch]);
 

--- a/src/containers/chat/index.tsx
+++ b/src/containers/chat/index.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useMemo, useState} from 'react';
 import {
   FlatList,
+  KeyboardAvoidingView,
   Platform,
   StatusBar,
   StyleSheet,
@@ -63,28 +64,32 @@ const Chat = ({route}: any) => {
         leftIcon={Images.back}
       />
 
-      <Box margin="s" flex={1} backgroundColor="mainBackground">
-        <FlatList
-          data={[]}
-          keyExtractor={(_, index) => index.toString()}
-          renderItem={() => <View />}
-        />
-        <Box margin={'l'} flexDirection={'row'} alignItems={'center'}>
-          <Box maxHeight={getScreenHeight(10)} marginRight={'m'} flex={1}>
-            <TextInput
-              style={styles.textInput}
-              placeholder={t('appNamespace.typeMessage')}
-              onChangeText={setMessage}
-              value={message}
-              numberOfLines={4}
-              multiline={true}
-            />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'} // Adjust behavior as needed
+        style={{flex: 1}}>
+        <Box margin="s" flex={1} backgroundColor="mainBackground">
+          <FlatList
+            data={[]}
+            keyExtractor={(_, index) => index.toString()}
+            renderItem={() => <View />}
+          />
+          <Box margin={'l'} flexDirection={'row'} alignItems={'center'}>
+            <Box maxHeight={getScreenHeight(10)} marginRight={'m'} flex={1}>
+              <TextInput
+                style={styles.textInput}
+                placeholder={t('appNamespace.typeMessage')}
+                onChangeText={setMessage}
+                value={message}
+                numberOfLines={4}
+                multiline={true}
+              />
+            </Box>
+            <TouchableOpacity>
+              <FastImage source={Images.send} style={styles.icon} />
+            </TouchableOpacity>
           </Box>
-          <TouchableOpacity>
-            <FastImage source={Images.send} style={styles.icon} />
-          </TouchableOpacity>
         </Box>
-      </Box>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
This PR fixes the issue when user goes to chat screen, and whenever user tries to type a message, now the entire text-input section will move above the keyboard. so that user can able to see the typos.

Fixes #4 

Here is the reference's to check more on what this PR fixes.


https://github.com/ShivamGoyal26/chatapp_rn/assets/57212870/78fe03a4-9107-4ba5-b3a4-c3e18a676c93

## Type of change
Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
- [ ] Go to the chats.
- [ ] Click on any chat.
- [ ] Type an message.

## Mandatory Tasks
- [X] Make sure you have self-reviewed the code.
